### PR TITLE
prevent errors in examples sections of fitGammaDist.R, FisherTest.R, fitLogNormDist.R, getPotentialDIMP.R

### DIFF
--- a/R/FisherTest.R
+++ b/R/FisherTest.R
@@ -101,7 +101,7 @@
 #'                 makeGRangesFromDataFrame(x, keep.extra.columns = TRUE))
 #'
 #' FisherTest(LR = data, control.names = c("C1", "C2"),
-#'         treatment.names = c("T1", "T2"), tv.cut = 0.25,
+#'         treatment.names = c("T1", "T2"), tv.cut = NULL,
 #'         pAdjustMethod="BH", pvalCutOff = 0.05, num.cores = 1L,
 #'         verbose=TRUE)
 #'

--- a/R/fitGammaDist.R
+++ b/R/fitGammaDist.R
@@ -62,7 +62,7 @@
 #'
 #' @examples
 #' set.seed(126)
-#' x <- rgamma(1000, alpha = 1.03, scale = 2.1)
+#' x <- rgamma(1000, shape = 1.03, scale = 2.1)
 #' fitGammaDist(x)
 #'
 #' @importFrom stats var stepfun as.formula coef AIC pweibull BIC vcov knots

--- a/R/fitLogNormDist.R
+++ b/R/fitLogNormDist.R
@@ -58,7 +58,7 @@
 #'
 #' @examples
 #' set.seed(126)
-#' x <- rgamma(1000, alpha = 1.03, scale = 2.1)
+#' x <- rgamma(1000, shape = 1.03, scale = 2.1)
 #' fitGammaDist(x)
 #'
 #' @importFrom stats var stepfun as.formula coef AIC pweibull BIC vcov knots

--- a/R/getPotentialDIMP.R
+++ b/R/getPotentialDIMP.R
@@ -50,11 +50,18 @@
 #'
 #' @examples
 #' num.points <- 1000
-#' HD <- GRangesList( sample1 = makeGRangesFromDataFrame(
-#'         data.frame(chr = "chr1", start = 1:num.points, end = 1:num.points,
-#'             strand = '*',
-#'             hdiv = rweibull(1:num.points, shape = 0.75, scale = 1)),
-#'         keep.extra.columns = TRUE))
+#' num.samples <- 250
+#' x <- data.frame(chr = "chr1", start = 1:num.samples,
+#'                 end = 1:num.samples,strand = '*',
+#'                 mC = rnbinom(size = num.samples, mu = 4, n = 500),
+#'                 uC = rnbinom(size = num.samples, mu = 4, n = 500))
+#' y <- data.frame(chr = "chr1", start = 1:num.samples,
+#'                 end = 1:num.samples, strand = '*',
+#'                 mC = rnbinom(size = num.samples, mu = 4, n = 500),
+#'                 uC = rnbinom(size = num.samples, mu = 4, n = 500))
+#' x <- makeGRangesFromDataFrame(x, keep.extra.columns = TRUE)
+#' y <- makeGRangesFromDataFrame(y, keep.extra.columns = TRUE)
+#' HD <- estimateDivergence(ref = x, indiv = list(y))
 #' nlms <- nonlinearFitDist(HD, column = 1, verbose = FALSE)
 #' getPotentialDIMP(LR = HD, nlms = nlms, div.col = 1, alpha = 0.05)
 #'


### PR DESCRIPTION
These minor changes cause the code in the examples to run without error.  
nonlinearFitDist.R is also failing for a similar reason (because it calls validateClass() on line 137).  
Fixing nonlinearFitDist.R example code was not done because the simple fix would mess up the idea being expressed in the example, the idea about the best fit. 

These 4 fixes should be okay and the example in nonlinearFitDist.R should be improved so that it does not cause error. 