### PR TITLE
changes to DESCRIPTION and R/countTest2.R to improve scores for 'R CM…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,5 +47,4 @@ Imports:
 RoxygenNote: 6.1.1
 Suggests: testthat, rmarkdown,
     knitr
-VignetteBuilder: rmarkdown,
-    knitr
+VignetteBuilder: knitr

--- a/R/countTest2.R
+++ b/R/countTest2.R
@@ -171,8 +171,9 @@ countTest2 <- function(DS, num.cores=1, countFilter=TRUE, CountPerBp=NULL,
                g2 <- which(lev[2] ==  group)
                m1 <- rowMeans(dc[ ,g1])
                m2 <- rowMeans(dc[ ,g2])
-               m1 <- sapply(m1, function(x) max(x,1)) # mean = 0 undefine the CV
-               m2 <- sapply(m2, function(x) max(x,1))
+               # mean = 0 undefine the CV:
+               m1 <- vapply(m1, function(x) max(x,1), numeric(1)) 
+               m2 <- vapply(m2, function(x) max(x,1), numeric(1))
                cv1 <- apply(dc[ ,g1], 1, sd)/m1
                cv2 <- apply(dc[ ,g2], 1, sd)/m2
            } else {


### PR DESCRIPTION
…D BiocCheck MethylIT' from Error2Warn11Note9 to Error0Warn10Note8: the change to DESCRIPTION changes the last two lines to simply: 'VignetteBuilder: knitr'..the change to R/countTest2.R replaces two calls to sapply() with two calls to vapply()