### PR TITLE
changed 2 lines in R/countTest2.R: we replaced '1:nrow(X)' with 'seq_…

### DIFF
--- a/R/countTest2.R
+++ b/R/countTest2.R
@@ -241,7 +241,7 @@ countTest2 <- function(DS, num.cores=1, countFilter=TRUE, CountPerBp=NULL,
        if (verbose) message("*** GLM...")
        if (num.cores == 1) {
            tests = c()
-           for (k in 1:nrow(X)) {
+           for (k in seq_len(nrow(X))) {
                if (verbose) message("*** Processing sample", k, "\n")
                tests <- rbind(tests, .estimateGLM(x=X[k, ], groups=group,
                                                baseMV=baseMeanAndVar[k, ],
@@ -255,7 +255,7 @@ countTest2 <- function(DS, num.cores=1, countFilter=TRUE, CountPerBp=NULL,
            } else {
                bpparam <- SnowParam(workers = num.cores, type = "SOCK")
            }
-           tests <- bplapply(1:nrow(X),
+           tests <- bplapply(seq_len(nrow(X)),
                            function(k) .estimateGLM(x=X[k, ], groups=group,
                                                    baseMV=baseMeanAndVar[k, ],
                                                    w=w[k, ], MVrate=MVrate,


### PR DESCRIPTION
…len(nrow(X))' to fix 'R CMD BiocCheck' complaint: 'NOTE: Avoid 1:...; use seq_len() or seq_along()'...there are dozens of these '1:... to avoid in MethylIT.  When replacing them, we can check that all.equal agrees, as it does in this case of countTest2.R, where we get TRUE from this call: 'all.equal(seq_len(nrow(ds)),1:nrow(ds))'