### PR TITLE
updated 2 files: R/uniqueGRfilterByCov.R man/uniqueGRfilterByCov.Rd  …

### DIFF
--- a/R/uniqueGRfilterByCov.R
+++ b/R/uniqueGRfilterByCov.R
@@ -82,7 +82,7 @@
 #' ## Cytosine position with coordinates 12 & 15 (rows #2 & #5) can pass the
 #' ## filtering conditions of min.coverage = 4 and lead to meaningless
 #' ## situations with methylation levels p = 1/(1 + 0) = 1
-#' r1[c(2,5)]
+#' gr1[c(2,5)]
 #'
 #' ## The last situation can be prevent, in this case, by setting min.meth = 1:
 #' r1 <- uniqueGRfilterByCov(gr1, gr2, min.meth = 1, ignore.strand = TRUE)

--- a/R/validateClass.R
+++ b/R/validateClass.R
@@ -11,7 +11,7 @@
 #' @keywords internal
 #' @examples
 #' data(HD, nlms)
-#' PS <- getPotentialDIMP(LR = HD, nlms = nlms, div.col = 9L, alpha = 0.05)
+#' PS <- getPotentialDIMP(LR = HD, nlms = gof$nlms, div.col = 9L, alpha = 0.05)
 #' validateClass(HD)
 #' validateClass(PS)
 #'

--- a/man/uniqueGRfilterByCov.Rd
+++ b/man/uniqueGRfilterByCov.Rd
@@ -119,7 +119,7 @@ r1
 ## Cytosine position with coordinates 12 & 15 (rows #2 & #5) can pass the
 ## filtering conditions of min.coverage = 4 and lead to meaningless
 ## situations with methylation levels p = 1/(1 + 0) = 1
-r1[c(2,5)]
+gr1[c(2,5)]
 
 ## The last situation can be prevent, in this case, by setting min.meth = 1:
 r1 <- uniqueGRfilterByCov(gr1, gr2, min.meth = 1, ignore.strand = TRUE)

--- a/man/validateClass.Rd
+++ b/man/validateClass.Rd
@@ -30,7 +30,7 @@ S3 generic used internally by MethylIT to ensure correct object
 }
 \examples{
 data(HD, nlms)
-PS <- getPotentialDIMP(LR = HD, nlms = nlms, div.col = 9L, alpha = 0.05)
+PS <- getPotentialDIMP(LR = HD, nlms = gof$nlms, div.col = 9L, alpha = 0.05)
 validateClass(HD)
 validateClass(PS)
 


### PR DESCRIPTION
…fixes minor typo in @examples section from 'r1' to 'gr1' which will prevent one error when running 'R CMD check'