### PR TITLE
changed 2 files:

### DIFF
--- a/R/getPotentialDIMP.R
+++ b/R/getPotentialDIMP.R
@@ -37,7 +37,7 @@
 #'     for |TV|, then absolute must be set to TRUE.
 #' @param alpha A numerical value (usually alpha < 0.05) used to select
 #'     cytosine sites k with information divergence (DIV_k) for which Weibull
-#'     probability P[DIV_k > DIV(alpha)].
+#'     probability P`[DIV_k > DIV(alpha)]`.
 #' @param pval.col An integer denoting a column from each GRanges object from
 #'     LR where p-values are provided when \strong{dist.name == "None"} and
 #'     \strong{nlms == NULL}. Default is NULL. If NUll and

--- a/man/getPotentialDIMP.Rd
+++ b/man/getPotentialDIMP.Rd
@@ -52,7 +52,7 @@ for |TV|, then absolute must be set to TRUE.}
 
 \item{alpha}{A numerical value (usually alpha < 0.05) used to select
 cytosine sites k with information divergence (DIV_k) for which Weibull
-probability P\link{DIV_k > DIV(alpha)}.}
+probability P\verb{[DIV_k > DIV(alpha)]}.}
 
 \item{pval.col}{An integer denoting a column from each GRanges object from
 LR where p-values are provided when \strong{dist.name == "None"} and


### PR DESCRIPTION
M  R/getPotentialDIMP.R
M  man/getPotentialDIMP.Rd

In R, we change line 40 TO this by adding two backticks:
probability P`[DIV_k > DIV(alpha)]`.
..from this OLD way:
probability P[DIV_k > DIV(alpha)].

..after roxygenise, we get this NEW version:
probability P\verb{[DIV_k > DIV(alpha)]}.}
..from this OLD version:
probability P\link{DIV_k > DIV(alpha)}.}

..as you can see the OLD Rd is making a "link" where we do not mean for a link.  If you run ?getPotentialDIMP, you will see in the Help pane that we have a bad link and our "Arguments" section for "alpha" looks wrong and has that bad link.  This change fixes that to make it right again.  There are several other places where this problem is happening.  It looks like the new roxygen2 7.0.2 is making this happen.  This seems like the wrong way to use the backtick but several things I have tried to fix our currently bad ?getPotentialDIMP-Arguments-alpha did not work.  I will fix the other bad places but I thought we would try to reach agreement on this being an okay way to fix.

There are ten places that have this problem as we can see from this snippet of the **R CMD Check** output:

* checking Rd cross-references ... WARNING
Missing link or links in documentation object 'countTest2.Rd':
  ‘1’ ‘2’

Missing link or links in documentation object 'estimateDivergence.Rd':
  ‘1’

Missing link or links in documentation object 'estimateJDiv.Rd':
  ‘1’

Missing link or links in documentation object 'fitGGammaDist.Rd':
  ‘1’

Missing link or links in documentation object 'fitGammaDist.Rd':
  ‘1’

Missing link or links in documentation object 'fitLogNormDist.Rd':
  ‘1’

Missing link or links in documentation object 'getPotentialDIMP.Rd':
  ‘DIV_k > DIV(alpha)’

Missing link or links in documentation object 'ggamma.Rd':
  ‘X<=x’ ‘X > x’

Missing link or links in documentation object 'nonlinearFitDist.Rd':
  ‘1’

Missing link or links in documentation object 'weibull3P.Rd':
  ‘1’

See section 'Cross-references' in the 'Writing R Extensions' manual.